### PR TITLE
Fix: typo and add quote to custom event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Easily add Amplitude Analytics to your Gatsby site. Automatically tracks page vi
 module.exports = {
   plugins: [
     {
-      resolve: `gatsby-plugin-ampiltude-analytics`,
+      resolve: `gatsby-plugin-amplitude-analytics`,
       options: {
         // Specify the API key for your Amplitude Project (required)
         apiKey: "YOUR_AMPLITUDE_ANALYTICS_API_KEY",

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -27,8 +27,8 @@ exports.onRenderBody = (
       : ``
   }
   window.amplitudeEventTypes = {
-    outboundLinkClick: ${(pluginOptions.eventTypes || {}).outboundLinkClick || '"outbound link click"'},
-    pageView: ${(pluginOptions.eventTypes || {}).pageView || '"page view"'}
+    outboundLinkClick: "${(pluginOptions.eventTypes || {}).outboundLinkClick || 'outbound link click'}",
+    pageView: "${(pluginOptions.eventTypes || {}).pageView || 'page view'}"
   };
   if(${
     typeof pluginOptions.respectDNT !== `undefined` &&


### PR DESCRIPTION
## Changelog
### Fixed
- Typo in README.md

### Changed
- Add quote to custom event_type to avoid escaping stuff in gastby-config.json (I am lazy)

## Note
 Can you please commit `./babel-preset.js` as well? I have to grab the file from the published package to test things out.