### PR TITLE
Add ability to specify environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ module.exports = {
           saveEvents: true,
           includeUtm: true,
           includeReferrer: true
-        }
+        },
+        // Specify NODE_ENVs in which the plugin should be loaded (optional)
+        environments: ["production"],
       },
     },
   ],

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,6 +1,10 @@
-exports.onRouteUpdate = function({ location }) {
-  // Don't track while developing.
-  if (process.env.NODE_ENV === `production` && typeof window.amplitude === `object`) {
+exports.onRouteUpdate = function({ location }, pluginOptions) {
+  // Only track when in an environment specified by pluginOptions. Default to
+  // [`production`] if the config option is not present.
+  if (
+      (pluginOptions.environments || [`production`]).includes(process.env.NODE_ENV)
+      && typeof window.amplitude === `object`
+  ) {
     if (
       location &&
       typeof window.amplitudeExcludePaths !== `undefined` &&

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -4,7 +4,9 @@ exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV === `production`) {
+  // Only include if the current env is included in the environments specified in
+  // pluginOptions. Default to [`production`] if the config option is not present.
+  if ((pluginOptions.environments || [`production`]).includes(process.env.NODE_ENV)) {
     let amplitudeExcludePaths = []
     if (typeof pluginOptions.exclude !== `undefined`) {
       const Minimatch = require(`minimatch`).Minimatch


### PR DESCRIPTION
Hello! This PR adds the ability to specify an `environments` plugin option which dictates the `NODE_ENV`s in which the plugin will be loaded. If the config option is not specified then it will default to `["production"]`, so this should be fully backwards compatible.

Closes #8