### PR TITLE
Fix proptypes and propagation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-function OutboundLink(props) {
+function OutboundLink({eventType, eventProperties, ...props}) {
   return (
     <a
       {...props}
       onClick={e => {
-        const amplitudeEventType = props.eventType || window.amplitudeEventTypes.outboundLinkClick;
-        const amplitudeEventProperties = Object.assign({ href: props.href }, props.eventProperties);
-  
+        const amplitudeEventType = eventType || window.amplitudeEventTypes.outboundLinkClick;
+        const amplitudeEventProperties = Object.assign({ href: props.href }, eventProperties);
+
         if (typeof props.onClick === `function`) {
           props.onClick()
         }
@@ -49,7 +49,7 @@ OutboundLink.propTypes = {
   target: PropTypes.string,
   onClick: PropTypes.func,
   eventType: PropTypes.string,
-  eventProperties: PropTypes.string,
+  eventProperties: PropTypes.object,
 }
 
 export { OutboundLink }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-function OutboundLink({eventType, eventProperties, ...props}) {
+const OutboundLink = React.forwardRef(({eventType, eventProperties, ...props}, ref) => {
   return (
     <a
       {...props}
+      ref={ref}
       onClick={e => {
         const amplitudeEventType = eventType || window.amplitudeEventTypes.outboundLinkClick;
         const amplitudeEventProperties = Object.assign({ href: props.href }, eventProperties);
@@ -42,7 +43,7 @@ function OutboundLink({eventType, eventProperties, ...props}) {
       }}
     />
   )
-}
+})
 
 OutboundLink.propTypes = {
   href: PropTypes.string,


### PR DESCRIPTION
The propType for eventProperties was marked as string, but it is actually an object.

Additionally, this was blindly passing all of the props through to the `<a>` tag which doesn't know about eventType or eventProperties. This didn't cause actual problems, but was throwing errors in the console.

Finally, forwarded the ref (if any) from the parent to the `<a>` tag for better compatibility with libraries like material ui