### PR TITLE
Correct link to available options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ The default values for these events are "outbound link click" and "page view".
 
 ## The "amplitudeConfig" option
 
-Configuration settings passed to the `amplitude.getInstance().init()` call. This option allows you to enable automatic collection of UTM params and referrer info and change persistence and upload behavior. See https://developers.amplitude.com/#platform-specific-settings for a full list of available options.
+Configuration settings passed to the `amplitude.getInstance().init()` call. This option allows you to enable automatic collection of UTM params and referrer info and change persistence and upload behavior. See https://developers.amplitude.com/docs/advanced-settings for a full list of available options.


### PR DESCRIPTION
The link to available options was a broken link that sent you to the "How Amplitude Works" page rather than the page I believe you intend, which is the advanced settings page that includes the available options list along with possible and default values. 

Hope this helps!